### PR TITLE
Fix example linting errors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         if: ${{ false }}
         uses: vaibhav-jain/spectral-action/@v2.6.1
         with:
-          file_path: keymanager-oapi.yaml
+          file_path: remote-signing-oapi.yaml
 
       - name: Bundle spec
         uses: mpetrunic/swagger-cli-action@v1.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,9 +8,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      # Temporarily disable linting in the first pass
+
       - name: Lint spec
-        if: ${{ false }}
         uses: vaibhav-jain/spectral-action/@v2.6.1
         with:
           file_path: remote-signing-oapi.yaml

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -9,7 +9,7 @@ rules:
   operation-tag-defined: error
   paths-snake-case:
     description: All YAML paths MUST follow snake-case
-    severity: error
+    severity: warn
     recommended: true
     message: "path is not snake-case: {{error}}"
     given: $.paths[*]~
@@ -19,7 +19,7 @@ rules:
         match: "^\/([a-z0-9]+(_[a-z0-9]+)*)?(\/[a-z0-9]+(_[a-z0-9]+)*|\/{.+})*$"
   parameters-snake-case-alphanumeric:
     description: Path parameters MUST follow snake case
-    severity: error
+    severity: warn
     recommended: true
     message: "{{property}} parameter is not snake case: {{error}}"
     given: $..parameters[?(@.in == 'path' || @.in == 'query')].name

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -19,7 +19,7 @@ rules:
         match: "^\/([a-z0-9]+(_[a-z0-9]+)*)?(\/[a-z0-9]+(_[a-z0-9]+)*|\/{.+})*$"
   parameters-snake-case-alphanumeric:
     description: Path parameters MUST follow snake case
-    severity: warn
+    severity: error
     recommended: true
     message: "{{property}} parameter is not snake case: {{error}}"
     given: $..parameters[?(@.in == 'path' || @.in == 'query')].name

--- a/signing/paths/sign.yaml
+++ b/signing/paths/sign.yaml
@@ -399,17 +399,17 @@ post:
                         signature: "0xb86aecf4e9673e9ac774883f03c46c2cfe59320e441abfc2e2bbaeda2193f58c57a3aec0ae63ba17d3b1cb81bd548689004773c1867cf047e1a2d5c3c51973fca33040cae49bee51bf4d2e23786f51dc5672bff5e9df8f7bc5fadae6be5c146e"
           BLOCK (DEPRECATED):
             value:
-              type: BLOCK
+              type: "BLOCK"
               signingRoot: '0xf6ab1a0a4a712f544f99b53cb8c2c2625859a134fb5c9f1b2cb96e13dd88bd62'
-              forkInfo:
+              fork_info:
                 fork:
                   previousVersion: '0x00000001'
                   currentVersion: '0x00000001'
-                  epoch: 1
-                genesisValidatorsRoot: '0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673'
+                  epoch: "1"
+                genesis_validators_root: '0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673'
               block:
-                slot: 0
-                proposerIndex: 5
+                slot: "0"
+                proposerIndex: "5"
                 parentRoot: '0xb2eedb01adbd02c828d5eec09b4c70cbba12ffffba525ebf48aca33028e8ad89'
                 stateRoot: '0x0000000000000000000000000000000000000000000000000000000000000000'
                 body:
@@ -449,14 +449,14 @@ post:
             value:
               type: 'AGGREGATION_SLOT'
               signingRoot: '0x1fb90dd6e8b2670e6949347bc4eaacd37f9b6cc6e42c559973e362c800e853b9'
-              forkInfo:
+              fork_info:
                 fork:
                   previousVersion: '0x00000001'
                   currentVersion: '0x00000001'
-                  epoch: 1
-                genesisValidatorsRoot: '0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673'
-              aggregationSlot:
-                slot: 119
+                  epoch: "1"
+                genesis_validators_root: '0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673'
+              aggregation_slot:
+                slot: "119"
           AGGREGATE_AND_PROOF:
             value:
               type: "AGGREGATE_AND_PROOF"


### PR DESCRIPTION
Fix linting errors on examples. Some of the examples had the wrong field names. 

* Updates examples so have they correct field names
* Re-enables linting check for openapi
* Changed the paths-snake-case rule severity to warn as this is not easily fixable right now without breaking changes to the API