### PR TITLE
Relayer signature forwarding

### DIFF
--- a/signing/paths/public_keys.yaml
+++ b/signing/paths/public_keys.yaml
@@ -18,12 +18,15 @@ get:
                   properties:
                     pubkey:
                       type: string
+                    relayer_signature:
+                      type: boolean                      
                     block_properties:
                       type: array
                       items:
                         type: string
             example: 
               - pubkey: '0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a'
+                relayer_signature: true              
                 block_properties: ['.execution_payload.fee_recipient', '.graffiti']
     '400':
       description: 'Bad request format'

--- a/signing/paths/public_keys.yaml
+++ b/signing/paths/public_keys.yaml
@@ -18,15 +18,12 @@ get:
                   properties:
                     pubkey:
                       type: string
-                    relayer_signature:
-                      type: boolean
                     block_properties:
                       type: array
                       items:
                         type: string
             example: 
               - pubkey: '0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a'
-                relayer_signature: true
                 block_properties: ['.execution_payload.fee_recipient', '.graffiti']
     '400':
       description: 'Bad request format'

--- a/signing/paths/public_keys.yaml
+++ b/signing/paths/public_keys.yaml
@@ -12,8 +12,20 @@ get:
           schema:
             type: array
             items:
-              type: string
-              example: '0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a'
+              oneOf:  
+                - type: string
+                - type: object
+                  properties:
+                    pubkey:
+                      type: string
+                    block_properties:
+                      type: array
+                      items:
+                        type: string
+            example: 
+              pubkey: '0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a'
+              block_properties: ['.execution_payload.fee_recipient', '.graffiti']
+
     '400':
       description: 'Bad request format'
     '500':

--- a/signing/paths/public_keys.yaml
+++ b/signing/paths/public_keys.yaml
@@ -27,7 +27,7 @@ get:
             example: 
               - pubkey: '0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a'
                 relayer_signature: true
-                block_properties: ['.execution_payload.fee_recipient', '.graffiti'] # Example of an object item
+                block_properties: ['.execution_payload.fee_recipient', '.graffiti']
     '400':
       description: 'Bad request format'
     '500':

--- a/signing/paths/public_keys.yaml
+++ b/signing/paths/public_keys.yaml
@@ -18,14 +18,16 @@ get:
                   properties:
                     pubkey:
                       type: string
+                    relayer_signature:
+                      type: boolean
                     block_properties:
                       type: array
                       items:
                         type: string
             example: 
-              pubkey: '0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a'
-              block_properties: ['.execution_payload.fee_recipient', '.graffiti']
-
+              - pubkey: '0x93247f2209abcacf57b75a51dafae777f9dd38bc7053d1af526f220a7489a6d3a2753e5f3e8b1cfe39b56f43611df74a'
+                relayer_signature: true
+                block_properties: ['.execution_payload.fee_recipient', '.graffiti'] # Example of an object item
     '400':
       description: 'Bad request format'
     '500':

--- a/signing/paths/sign.yaml
+++ b/signing/paths/sign.yaml
@@ -49,7 +49,17 @@ post:
           BLOCK_V2 (DENEB):
             value:
               type: "BLOCK_V2"
-              proofs: [{proof : "", index : "401"}]
+              proofs:
+                - index: "401"
+                  proof: 
+                  - "0x779b271e405f605a48317e56cac7d45363866a55dd4e0895f4df104d09e7a192"
+                  - "0x644d4588f408c24fe29e8ca8b668d6cffcedd9496682cda1ad564532f67f58f9"
+                  - "0xb4a81f606555f57fa28b1a394acfc79a2c4b4a12cb406fc4efba434833732322"
+                  - "0xdc07f92f1f0079b9724556f0e74b30b816b20beb9dd98629a5d85d7ff1ee7276"
+                  - "0xface4c8dc79e2dad391b534b69530d4470eb551927548555854d2022fe2b22a0"
+                  - "0x336488033fe5f3ef4ccc12af07b9370b92e553e35ecb4a337a1b1c0e4afe1e0e"
+                  - "0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71"
+                  - "0x60ba834cd8f04bb6edf3276fc70d9731148ee1c8e1efd6b7c685f82e721176ef"
               signingRoot: "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc"
               fork_info:
                 fork:
@@ -66,9 +76,19 @@ post:
                   state_root: "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"
                   body_root: "0xa759d8029a69d4fdd8b3996086e9722983977e4efc1f12f4098ea3d93e868a6b"
           BLOCK_V2 (CAPELLA):
-            value:
+            value:   
               type: "BLOCK_V2"
-              proofs: [{proof : "", index : "401"}]
+              proofs:
+                - index: "401"
+                  proof: 
+                  - "0x779b271e405f605a48317e56cac7d45363866a55dd4e0895f4df104d09e7a192"
+                  - "0x644d4588f408c24fe29e8ca8b668d6cffcedd9496682cda1ad564532f67f58f9"
+                  - "0xb4a81f606555f57fa28b1a394acfc79a2c4b4a12cb406fc4efba434833732322"
+                  - "0xdc07f92f1f0079b9724556f0e74b30b816b20beb9dd98629a5d85d7ff1ee7276"
+                  - "0xface4c8dc79e2dad391b534b69530d4470eb551927548555854d2022fe2b22a0"
+                  - "0x336488033fe5f3ef4ccc12af07b9370b92e553e35ecb4a337a1b1c0e4afe1e0e"
+                  - "0xdb56114e00fdd4c1f85c892bf35ac9a89289aaecb1ebd0a96cde606a748b5d71"
+                  - "0x60ba834cd8f04bb6edf3276fc70d9731148ee1c8e1efd6b7c685f82e721176ef"
               signingRoot: "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc"
               fork_info:
                 fork:

--- a/signing/paths/sign.yaml
+++ b/signing/paths/sign.yaml
@@ -49,6 +49,7 @@ post:
           BLOCK_V2 (DENEB):
             value:
               type: "BLOCK_V2"
+              proofs: [{proof : "", index : "401"}]
               signingRoot: "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc"
               fork_info:
                 fork:
@@ -67,6 +68,7 @@ post:
           BLOCK_V2 (CAPELLA):
             value:
               type: "BLOCK_V2"
+              proofs: [{proof : "", index : "401"}]
               signingRoot: "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc"
               fork_info:
                 fork:

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -3,11 +3,6 @@ components:
     Verifying:
       type: "object"
       properties:
-        relayer_signature: 
-            type: "string"
-            nullable: true
-            description: Signature from Relayer
-            example: '0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505'
         proofs:
           type: "array"
           nullable: true

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -16,10 +16,6 @@ components:
                 type: "string"
                 description: Generalized index of the field
                 example: "401"
-              value:
-                type: "string"
-                description: SSZ hash of the field
-                example: ""
             required:
               - proof
               - index

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -494,8 +494,6 @@ components:
           format: uint64
         pubkey:
           type: string
-    
-    
     BeaconBlockSigning:
       allOf:
         - $ref: '#/components/schemas/Verifying'
@@ -507,7 +505,6 @@ components:
               type: "string"
               description: Signing Request type
               example: 'BLOCK_V2'
-
     BeaconBlockRequest:
       type: object
       properties:

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -3,6 +3,11 @@ components:
     Verifying:
       type: "object"
       properties:
+        relayer_signature: 
+            type: "string"
+            nullable: true
+            description: Signature from Relayer
+            example: '0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505'
         proofs:
           type: "array"
           nullable: true

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -9,9 +9,10 @@ components:
             type: "object"
             properties:
               proof:
-                type: "string"
-                description: Merkle proof against the block body root included in the request 
-                example: ""
+                type: "array"
+                description: Merkle proof against the block body root included in the request
+                items:
+                  $ref: "#/components/schemas/Proof"
               index:
                 type: "string"
                 description: Generalized index of the field
@@ -19,6 +20,9 @@ components:
             required:
               - proof
               - index
+    Proof:
+      type: "string"
+      example: "0x779b271e405f605a48317e56cac7d45363866a55dd4e0895f4df104d09e7a192"
     Signing:
       type: "object"
       properties:
@@ -489,6 +493,8 @@ components:
           format: uint64
         pubkey:
           type: string
+    
+    
     BeaconBlockSigning:
       allOf:
         - $ref: '#/components/schemas/Verify'

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -9,6 +9,11 @@ components:
           items:
             type: "object"
             properties:
+              relayer_signature: 
+                type: "string"
+                nullable: true
+                description: Signature from Relayer
+                example: '0x1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505cc411d61252fb6cb3fa0017b679f8bb2305b26a285fa2737f175668d0dff91cc1b66ac1fb663c9bc59509846d6ec05345bd908eda73e670af888da41af171505'
               proof:
                 type: "array"
                 description: Merkle proof against the block body root included in the request

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -1,10 +1,11 @@
 components:
   schemas:
-    Verify:
+    Verifying:
       type: "object"
       properties:
         proofs:
           type: "array"
+          nullable: true
           items:
             type: "object"
             properties:
@@ -497,7 +498,7 @@ components:
     
     BeaconBlockSigning:
       allOf:
-        - $ref: '#/components/schemas/Verify'
+        - $ref: '#/components/schemas/Verifying'
         - $ref: '#/components/schemas/Signing'
         - $ref: '#/components/schemas/BeaconBlockRequest'
         - type: object

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -1,5 +1,28 @@
 components:
   schemas:
+    Verify:
+      type: "object"
+      properties:
+        proofs:
+          type: "array"
+          items:
+            type: "object"
+            properties:
+              proof:
+                type: "string"
+                description: Merkle proof against the block body root included in the request 
+                example: ""
+              index:
+                type: "string"
+                description: Generalized index of the field
+                example: "401"
+              value:
+                type: "string"
+                description: SSZ hash of the field
+                example: ""
+            required:
+              - proof
+              - index
     Signing:
       type: "object"
       properties:
@@ -472,6 +495,7 @@ components:
           type: string
     BeaconBlockSigning:
       allOf:
+        - $ref: '#/components/schemas/Verify'
         - $ref: '#/components/schemas/Signing'
         - $ref: '#/components/schemas/BeaconBlockRequest'
         - type: object


### PR DESCRIPTION
### Motivation

This proposal is built upon the [Verifying Remote Signing](https://github.com/ethereum/remote-signing-api/pull/10), introducing a mechanism for remote signers to authenticate the provenance of the relayer responsible for signing a blinded block. It aims to enhance the integrity of the signing process.

### Rationale

This enhancement provides verification capabilities of the block proposals content to remote signers prior to signing the block, thereby facilitating a trustless operational setup between the validator client and the remote signer.

The specification aims to optionally extend the capabilities of the remote signer API while maintaining compatibility with the current API with the following (optional, flag-enabled) addition:

- **Validate BlindedBlock authenticity:**
In a MEV context, when the signing request is built for a BlindedBlock, in order to validate the authenticity of the BlindedBlock, the validator client can include the relayer's signature by adding the `signature` field from the [SignedBeaconBlockHeader](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblockheader) to verify that the signature was performed by a given relayer.

### Specification Overview

This specification proposes a structured methodology to refine the interaction between validator clients and the remote signer.

#### Property Specification in validator client

This process involves validator to knowing by flags where to find the remote signer and which properties the remote signer is ready to validate:

- **Relayer Signature**: Specifically for block proposals that are instances of [SignedBeaconBlockHeader](https://github.com/ethereum/consensus-specs/blob/v1.3.0/specs/phase0/beacon-chain.md#signedbeaconblockheader), indicating whether a relayer's signature should be forwarded to the remote signer.

#### Verifying Signature Request in `/api/v1/eth2/sign/{pubkey}`

Enhancing signature requests with the inclusion of relayer signatures. Based on the properties specified for each validator in the previous step, the verifying remote signer will perform before signing:

- **Relayer Signature Validation**: If applicable, the remote signer validates that the BLS signature in the `signature` field was indeed generated by the specified relayer, thereby confirming the authenticity of the BlindedBlock in the signing request.


### Sequence Diagram

<img width="1083" alt="image" src="https://github.com/ethereum/remote-signing-api/assets/15982330/fef345df-8080-4965-a19b-2a22a387ed9d">