### PR TITLE
Adding Gloas changes

### DIFF
--- a/remote-signing-oapi.yaml
+++ b/remote-signing-oapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: 'Remote Signing API'
   description: 'Remote Signing API for communication between remote signers and Ethereum validator clients.'
-  version: 'v1.3.0'
+  version: 'v1.4.0'
   contact:
     name: Ethereum Github
     url: https://github.com/ethereum/remote-signing-api/issues

--- a/signing/paths/sign.yaml
+++ b/signing/paths/sign.yaml
@@ -31,6 +31,10 @@ post:
             - $ref: '../schemas.yaml#/components/schemas/SyncCommitteeSelectionProofSigning'
             - $ref: '../schemas.yaml#/components/schemas/SyncCommitteeContributionAndProofSigning'
             - $ref: '../schemas.yaml#/components/schemas/ValidatorRegistrationSigning'
+            - $ref: '../schemas.yaml#/components/schemas/ExecutionPayloadBidSigning'
+            - $ref: '../schemas.yaml#/components/schemas/ExecutionPayloadEnvelopeSigning'
+            - $ref: '../schemas.yaml#/components/schemas/PayloadAttestationMessageSigning'
+            - $ref: '../schemas.yaml#/components/schemas/ProposerPreferencesSigning'
           discriminator:
             propertyName: type
             mapping:
@@ -47,6 +51,10 @@ post:
               SYNC_COMMITTEE_SELECTION_PROOF: '../schemas.yaml#/components/schemas/SyncCommitteeSelectionProofSigning'
               SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF: '../schemas.yaml#/components/schemas/SyncCommitteeContributionAndProofSigning'
               VALIDATOR_REGISTRATION: '../schemas.yaml#/components/schemas/ValidatorRegistrationSigning'
+              EXECUTION_PAYLOAD_BID: '../schemas.yaml#/components/schemas/ExecutionPayloadBidSigning'
+              EXECUTION_PAYLOAD_ENVELOPE: '../schemas.yaml#/components/schemas/ExecutionPayloadEnvelopeSigning'
+              PAYLOAD_ATTESTATION_MESSAGE: '../schemas.yaml#/components/schemas/PayloadAttestationMessageSigning'
+              PROPOSER_PREFERENCES: '../schemas.yaml#/components/schemas/ProposerPreferencesSigning'
         examples:
           BLOCK_V2 (FULU):
             value:

--- a/signing/paths/sign.yaml
+++ b/signing/paths/sign.yaml
@@ -58,6 +58,24 @@ post:
               PROPOSER_PREFERENCES: '../schemas.yaml#/components/schemas/ProposerPreferencesSigning'
               BUILDER_REQUEST_AUTH: '../schemas.yaml#/components/schemas/BuilderRequestAuthSigning'
         examples:
+          BLOCK_V2 (GLOAS):
+            value:
+              type: "BLOCK_V2"
+              signingRoot: "0xaa2e0c465c1a45d7b6637fcce4ad6ceb71fc12064b548078d619a411f0de8adc"
+              fork_info:
+                fork:
+                  previous_version: "0x00000001"
+                  current_version: "0x00000001"
+                  epoch: "1"
+                genesis_validators_root: "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+              beacon_block:
+                version: "GLOAS"
+                block_header:
+                  slot: "0"
+                  proposer_index: "4666673844721362956"
+                  parent_root: "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"
+                  state_root: "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"
+                  body_root: "0xa759d8029a69d4fdd8b3996086e9722983977e4efc1f12f4098ea3d93e868a6b"
           BLOCK_V2 (FULU):
             value:
               type: "BLOCK_V2"
@@ -523,6 +541,35 @@ post:
                 genesis_validators_root: '0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673'
               aggregation_slot:
                 slot: "119"
+          AGGREGATE_AND_PROOF_V2 (GLOAS):
+            value:
+              type: "AGGREGATE_AND_PROOF_V2"
+              signingRoot: "0x247535806f76143fe4798427b2a79b85340c1a029a9e08581995b60e4e45c9e0"
+              fork_info:
+                fork:
+                  previous_version: "0x00000001"
+                  current_version: "0x00000001"
+                  epoch: "1"
+                genesis_validators_root: "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+              aggregate_and_proof:
+                version: "GLOAS"
+                data:
+                  aggregator_index: "1"
+                  aggregate:
+                    aggregation_bits: "0x0000000000000000000000000000000000000000000101"
+                    data:
+                      slot: "0"
+                      index: "0"
+                      beacon_block_root: "0x100814c335d0ced5014cfa9d2e375e6d9b4e197381f8ce8af0473200fdc917fd"
+                      source:
+                        epoch: "0"
+                        root: "0x0000000000000000000000000000000000000000000000000000000000000000"
+                      target:
+                        epoch: "0"
+                        root: "0x100814c335d0ced5014cfa9d2e375e6d9b4e197381f8ce8af0473200fdc917fd"
+                    signature: "0xa627242e4a5853708f4ebf923960fb8192f93f2233cd347e05239d86dd9fb66b721ceec1baeae6647f498c9126074f1101a87854d674b6eebc220fd8c3d8405bdfd8e286b707975d9e00a56ec6cbbf762f23607d490f0bbb16c3e0e483d51875"
+                    committee_bits: "0x0000000000000001"
+                  selection_proof: "0xa63f73a03f1f42b1fd0a988b614d511eb346d0a91c809694ef76df5ae021f0f144d64e612d735bc8820950cf6f7f84cd0ae194bfe3d4242fe79688f83462e3f69d9d33de71aab0721b7dab9d6960875e5fdfd26b171a75fb51af822043820c47"
           AGGREGATE_AND_PROOF_V2 (FULU):
             value:
               type: "AGGREGATE_AND_PROOF_V2"
@@ -842,6 +889,117 @@ post:
                 withdrawal_credentials: "0x39722cbbf8b91a4b9045c5e6175f1001eac32f7fcd5eccda5c6e62fc4e638508"
                 amount: "32"
                 genesis_fork_version: "0x00000001"
+
+          EXECUTION_PAYLOAD_BID (GLOAS):
+            value:
+              type: "EXECUTION_PAYLOAD_BID"
+              fork_info:
+                fork:
+                  previous_version: "0x00000001"
+                  current_version: "0x00000001"
+                  epoch: "1"
+                genesis_validators_root: "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+              execution_payload_bid:
+                version: "GLOAS"
+                data:
+                  parent_block_hash: "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"
+                  parent_block_root: "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"
+                  block_hash: "0xa759d8029a69d4fdd8b3996086e9722983977e4efc1f12f4098ea3d93e868a6b"
+                  prev_randao: "0x100814c335d0ced5014cfa9d2e375e6d9b4e197381f8ce8af0473200fdc917fd"
+                  fee_recipient: "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a9"
+                  gas_limit: "30000000"
+                  builder_index: "1"
+                  slot: "1"
+                  value: "1000000000"
+                  execution_payment: "0"
+                  blob_kzg_commitments: []
+                  execution_requests_root: "0x0000000000000000000000000000000000000000000000000000000000000000"
+
+          EXECUTION_PAYLOAD_ENVELOPE (GLOAS):
+            value:
+              type: "EXECUTION_PAYLOAD_ENVELOPE"
+              fork_info:
+                fork:
+                  previous_version: "0x00000001"
+                  current_version: "0x00000001"
+                  epoch: "1"
+                genesis_validators_root: "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+              execution_payload_envelope:
+                version: "GLOAS"
+                data:
+                  payload:
+                    parent_hash: "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"
+                    fee_recipient: "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a9"
+                    state_root: "0xfd18cf40cc907a739be483f1ca0ee23ad65cdd3df23205eabc6d660a75d1f54e"
+                    receipts_root: "0x0000000000000000000000000000000000000000000000000000000000000000"
+                    logs_bloom: "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                    prev_randao: "0x100814c335d0ced5014cfa9d2e375e6d9b4e197381f8ce8af0473200fdc917fd"
+                    block_number: "1"
+                    gas_limit: "30000000"
+                    gas_used: "0"
+                    timestamp: "1"
+                    extra_data: "0x"
+                    base_fee_per_gas: "1"
+                    block_hash: "0xa759d8029a69d4fdd8b3996086e9722983977e4efc1f12f4098ea3d93e868a6b"
+                    transactions: []
+                    withdrawals: []
+                    blob_gas_used: "0"
+                    excess_blob_gas: "0"
+                    block_access_list: "0x"
+                    slot_number: "1"
+                  execution_requests:
+                    deposits: []
+                    withdrawals: []
+                    consolidations: []
+                    builder_deposits: []
+                    builder_exits: []
+                  builder_index: "1"
+                  beacon_block_root: "0x235bc3400c2839fd856a524871200bd5e362db615fc4565e1870ed9a2a936464"
+                  parent_beacon_block_root: "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"
+
+          PAYLOAD_ATTESTATION_MESSAGE (GLOAS):
+            value:
+              type: "PAYLOAD_ATTESTATION_MESSAGE"
+              fork_info:
+                fork:
+                  previous_version: "0x00000001"
+                  current_version: "0x00000001"
+                  epoch: "1"
+                genesis_validators_root: "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+              payload_attestation_message:
+                version: "GLOAS"
+                data:
+                  beacon_block_root: "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"
+                  slot: "1"
+                  payload_present: true
+                  blob_data_available: true
+
+          PROPOSER_PREFERENCES (GLOAS):
+            value:
+              type: "PROPOSER_PREFERENCES"
+              fork_info:
+                fork:
+                  previous_version: "0x00000001"
+                  current_version: "0x00000001"
+                  epoch: "1"
+                genesis_validators_root: "0x04700007fabc8282644aed6d1c7c9e21d38a03a0c4ba193f3afe428824b3a673"
+              proposer_preferences:
+                version: "GLOAS"
+                data:
+                  dependent_root: "0x367cbd40ac7318427aadb97345a91fa2e965daf3158d7f1846f1306305f41bef"
+                  proposal_slot: "32"
+                  validator_index: "1"
+                  fee_recipient: "0x6fdfab408c56b6105a76eff5c0435d09fc6ed7a9"
+                  target_gas_limit: "60000000"
+
+          BUILDER_REQUEST_AUTH (GLOAS):
+            value:
+              type: "BUILDER_REQUEST_AUTH"
+              builder_request_auth:
+                version: "GLOAS"
+                data:
+                  data: "0x68747470733a2f2f6275696c6465722e6578616d706c652e6f7267"
+                  slot: "32"
 
   responses:
     '200':

--- a/signing/paths/sign.yaml
+++ b/signing/paths/sign.yaml
@@ -35,6 +35,7 @@ post:
             - $ref: '../schemas.yaml#/components/schemas/ExecutionPayloadEnvelopeSigning'
             - $ref: '../schemas.yaml#/components/schemas/PayloadAttestationMessageSigning'
             - $ref: '../schemas.yaml#/components/schemas/ProposerPreferencesSigning'
+            - $ref: '../schemas.yaml#/components/schemas/BuilderRequestAuthSigning'
           discriminator:
             propertyName: type
             mapping:
@@ -55,6 +56,7 @@ post:
               EXECUTION_PAYLOAD_ENVELOPE: '../schemas.yaml#/components/schemas/ExecutionPayloadEnvelopeSigning'
               PAYLOAD_ATTESTATION_MESSAGE: '../schemas.yaml#/components/schemas/PayloadAttestationMessageSigning'
               PROPOSER_PREFERENCES: '../schemas.yaml#/components/schemas/ProposerPreferencesSigning'
+              BUILDER_REQUEST_AUTH: '../schemas.yaml#/components/schemas/BuilderRequestAuthSigning'
         examples:
           BLOCK_V2 (FULU):
             value:

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -807,8 +807,22 @@ components:
             description: variable-length bytes (RLP-encoded transaction)
         withdrawals:
           type: array
+          description: List of validator withdrawals (Capella+).
           items:
             type: object
+            properties:
+              index:
+                type: string
+                format: uint64
+              validator_index:
+                type: string
+                format: uint64
+              address:
+                type: string
+                description: Bytes20 hexadecimal
+              amount:
+                type: string
+                format: uint64
         blob_gas_used:
           type: string
           format: uint64

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -341,6 +341,66 @@ components:
           required:
             - type
             - validator_registration
+    ExecutionPayloadBidSigning:
+      allOf:
+        - $ref: '#/components/schemas/Signing'
+        - type: object
+          properties:
+            type:
+              type: "string"
+              description: Signing Request type
+              enum:
+                - 'EXECUTION_PAYLOAD_BID'
+            execution_payload_bid:
+              "$ref": "#/components/schemas/ExecutionPayloadBid"
+          required:
+            - type
+            - execution_payload_bid
+    ExecutionPayloadEnvelopeSigning:
+      allOf:
+        - $ref: '#/components/schemas/Signing'
+        - type: object
+          properties:
+            type:
+              type: "string"
+              description: Signing Request type
+              enum:
+                - 'EXECUTION_PAYLOAD_ENVELOPE'
+            execution_payload_envelope:
+              "$ref": "#/components/schemas/ExecutionPayloadEnvelope"
+          required:
+            - type
+            - execution_payload_envelope
+    PayloadAttestationMessageSigning:
+      allOf:
+        - $ref: '#/components/schemas/Signing'
+        - type: object
+          properties:
+            type:
+              type: "string"
+              description: Signing Request type
+              enum:
+                - 'PAYLOAD_ATTESTATION_MESSAGE'
+            payload_attestation_message:
+              "$ref": "#/components/schemas/PayloadAttestationData"
+          required:
+            - type
+            - payload_attestation_message
+    ProposerPreferencesSigning:
+      allOf:
+        - $ref: '#/components/schemas/Signing'
+        - type: object
+          properties:
+            type:
+              type: "string"
+              description: Signing Request type
+              enum:
+                - 'PROPOSER_PREFERENCES'
+            proposer_preferences:
+              "$ref": "#/components/schemas/ProposerPreferences"
+          required:
+            - type
+            - proposer_preferences
     RandaoReveal:
       type: "object"
       properties:
@@ -632,6 +692,174 @@ components:
           format: uint64
         pubkey:
           type: string
+    ExecutionPayloadBid:
+      type: object
+      description: >-
+        SSZ container signed by a builder using DOMAIN_BEACON_BUILDER (0x0B000000)
+        in Glamsterdam (ePBS) for proposing an execution payload bid.
+      properties:
+        parent_block_hash:
+          type: string
+          description: Bytes32 hexadecimal
+        parent_block_root:
+          type: string
+          description: Bytes32 hexadecimal
+        block_hash:
+          type: string
+          description: Bytes32 hexadecimal
+        prev_randao:
+          type: string
+          description: Bytes32 hexadecimal
+        fee_recipient:
+          type: string
+          description: Bytes20 hexadecimal
+        gas_limit:
+          type: string
+          format: uint64
+        builder_index:
+          type: string
+          format: uint64
+        slot:
+          type: string
+          format: uint64
+        value:
+          type: string
+          format: uint64
+        execution_payment:
+          type: string
+          format: uint64
+        blob_kzg_commitments:
+          type: array
+          items:
+            type: string
+            description: Bytes48 hexadecimal KZG commitment
+        execution_requests_root:
+          type: string
+          description: Bytes32 hash-tree-root of the execution requests
+    ExecutionPayloadEnvelope:
+      type: object
+      description: >-
+        SSZ container signed by a builder using DOMAIN_BEACON_BUILDER (0x0B000000)
+        in Glamsterdam (ePBS) when revealing the actual execution payload.
+      properties:
+        payload:
+          description: 'Execution payload (Glamsterdam shape, see ExecutionPayloadGloas)'
+          $ref: '#/components/schemas/ExecutionPayloadGloas'
+        execution_requests:
+          description: 'Execution requests (deposits, withdrawals, consolidations)'
+          type: object
+        builder_index:
+          type: string
+          format: uint64
+        beacon_block_root:
+          type: string
+          description: Bytes32 hexadecimal
+    ExecutionPayloadGloas:
+      type: object
+      description: >-
+        Glamsterdam execution payload. Extends the Deneb execution payload with
+        block_access_list and slot_number fields (slot moved from envelope into
+        the payload in ePBS).
+      properties:
+        parent_hash:
+          type: string
+          description: Bytes32 hexadecimal
+        fee_recipient:
+          type: string
+          description: Bytes20 hexadecimal
+        state_root:
+          type: string
+          description: Bytes32 hexadecimal
+        receipts_root:
+          type: string
+          description: Bytes32 hexadecimal
+        logs_bloom:
+          type: string
+          description: Bytes256 hexadecimal
+        prev_randao:
+          type: string
+          description: Bytes32 hexadecimal
+        block_number:
+          type: string
+          format: uint64
+        gas_limit:
+          type: string
+          format: uint64
+        gas_used:
+          type: string
+          format: uint64
+        timestamp:
+          type: string
+          format: uint64
+        extra_data:
+          type: string
+          description: variable-length bytes
+        base_fee_per_gas:
+          type: string
+          description: UInt256 decimal
+        block_hash:
+          type: string
+          description: Bytes32 hexadecimal
+        transactions:
+          type: array
+          items:
+            type: string
+            description: variable-length bytes (RLP-encoded transaction)
+        withdrawals:
+          type: array
+          items:
+            type: object
+        blob_gas_used:
+          type: string
+          format: uint64
+        excess_blob_gas:
+          type: string
+          format: uint64
+        block_access_list:
+          type: string
+          description: variable-length bytes (block access list)
+        slot_number:
+          type: string
+          format: uint64
+    PayloadAttestationData:
+      type: object
+      description: >-
+        The data component of a PayloadAttestationMessage, signed by a PTC
+        validator using DOMAIN_PTC_ATTESTER (0x0C000000).
+      properties:
+        beacon_block_root:
+          type: string
+          description: Bytes32 hexadecimal
+          example: '0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2'
+        slot:
+          type: string
+          format: uint64
+          example: '1'
+        payload_present:
+          type: boolean
+          description: Whether the execution payload for this slot is present
+        blob_data_available:
+          type: boolean
+          description: Whether blob data is available for this slot
+    ProposerPreferences:
+      type: object
+      description: >-
+        Container signed by a proposer using DOMAIN_PROPOSER_PREFERENCES
+        (0x0D000000) to advertise their preferences (fee_recipient, gas_limit)
+        for an upcoming proposal slot.
+      properties:
+        proposal_slot:
+          type: string
+          format: uint64
+        validator_index:
+          type: string
+          format: uint64
+        fee_recipient:
+          type: string
+          description: Bytes20 hexadecimal
+        gas_limit:
+          type: string
+          format: uint64
     BeaconBlockSigning:
       allOf:
         - $ref: '#/components/schemas/Signing'

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -89,6 +89,7 @@ components:
             - $ref: '#/components/schemas/AggregateAndProofRequestDeneb'
             - $ref: '#/components/schemas/AggregateAndProofRequestElectra'
             - $ref: '#/components/schemas/AggregateAndProofRequestFulu'
+            - $ref: '#/components/schemas/AggregateAndProofRequestGloas'
           discriminator:
             propertyName: version
             mapping:
@@ -99,6 +100,7 @@ components:
               DENEB: '#/components/schemas/AggregateAndProofRequestDeneb'
               ELECTRA: '#/components/schemas/AggregateAndProofRequestElectra'
               FULU: '#/components/schemas/AggregateAndProofRequestFulu'
+              GLOAS: '#/components/schemas/AggregateAndProofRequestGloas'
       required:
         - aggregate_and_proof
     AggregateAndProofRequestPhase0:
@@ -186,6 +188,19 @@ components:
           type: string
           enum:
             - FULU
+          description: 'version to identify AggregateAndProof request type.'
+        data:
+          $ref: "#/components/schemas/AggregateAndProofElectra"
+      required:
+        - version
+        - data
+    AggregateAndProofRequestGloas:
+      type: object
+      properties:
+        version:
+          type: string
+          enum:
+            - GLOAS
           description: 'version to identify AggregateAndProof request type.'
         data:
           $ref: "#/components/schemas/AggregateAndProofElectra"
@@ -344,6 +359,7 @@ components:
     ExecutionPayloadBidSigning:
       allOf:
         - $ref: '#/components/schemas/Signing'
+        - $ref: '#/components/schemas/ExecutionPayloadBidRequest'
         - type: object
           properties:
             type:
@@ -351,14 +367,37 @@ components:
               description: Signing Request type
               enum:
                 - 'EXECUTION_PAYLOAD_BID'
-            execution_payload_bid:
-              "$ref": "#/components/schemas/ExecutionPayloadBid"
           required:
             - type
-            - execution_payload_bid
+    ExecutionPayloadBidRequest:
+      type: object
+      properties:
+        execution_payload_bid:
+          oneOf:
+            - $ref: '#/components/schemas/ExecutionPayloadBidRequestGloas'
+          discriminator:
+            propertyName: version
+            mapping:
+              GLOAS: '#/components/schemas/ExecutionPayloadBidRequestGloas'
+      required:
+        - execution_payload_bid
+    ExecutionPayloadBidRequestGloas:
+      type: object
+      properties:
+        version:
+          type: string
+          enum:
+            - GLOAS
+          description: 'version to identify ExecutionPayloadBid request type.'
+        data:
+          $ref: "#/components/schemas/ExecutionPayloadBidGloas"
+      required:
+        - version
+        - data
     ExecutionPayloadEnvelopeSigning:
       allOf:
         - $ref: '#/components/schemas/Signing'
+        - $ref: '#/components/schemas/ExecutionPayloadEnvelopeRequest'
         - type: object
           properties:
             type:
@@ -366,14 +405,37 @@ components:
               description: Signing Request type
               enum:
                 - 'EXECUTION_PAYLOAD_ENVELOPE'
-            execution_payload_envelope:
-              "$ref": "#/components/schemas/ExecutionPayloadEnvelope"
           required:
             - type
-            - execution_payload_envelope
+    ExecutionPayloadEnvelopeRequest:
+      type: object
+      properties:
+        execution_payload_envelope:
+          oneOf:
+            - $ref: '#/components/schemas/ExecutionPayloadEnvelopeRequestGloas'
+          discriminator:
+            propertyName: version
+            mapping:
+              GLOAS: '#/components/schemas/ExecutionPayloadEnvelopeRequestGloas'
+      required:
+        - execution_payload_envelope
+    ExecutionPayloadEnvelopeRequestGloas:
+      type: object
+      properties:
+        version:
+          type: string
+          enum:
+            - GLOAS
+          description: 'version to identify ExecutionPayloadEnvelope request type.'
+        data:
+          $ref: "#/components/schemas/ExecutionPayloadEnvelopeGloas"
+      required:
+        - version
+        - data
     PayloadAttestationMessageSigning:
       allOf:
         - $ref: '#/components/schemas/Signing'
+        - $ref: '#/components/schemas/PayloadAttestationMessageRequest'
         - type: object
           properties:
             type:
@@ -381,14 +443,37 @@ components:
               description: Signing Request type
               enum:
                 - 'PAYLOAD_ATTESTATION_MESSAGE'
-            payload_attestation_message:
-              "$ref": "#/components/schemas/PayloadAttestationData"
           required:
             - type
-            - payload_attestation_message
+    PayloadAttestationMessageRequest:
+      type: object
+      properties:
+        payload_attestation_message:
+          oneOf:
+            - $ref: '#/components/schemas/PayloadAttestationMessageRequestGloas'
+          discriminator:
+            propertyName: version
+            mapping:
+              GLOAS: '#/components/schemas/PayloadAttestationMessageRequestGloas'
+      required:
+        - payload_attestation_message
+    PayloadAttestationMessageRequestGloas:
+      type: object
+      properties:
+        version:
+          type: string
+          enum:
+            - GLOAS
+          description: 'version to identify PayloadAttestationMessage request type.'
+        data:
+          $ref: "#/components/schemas/PayloadAttestationDataGloas"
+      required:
+        - version
+        - data
     ProposerPreferencesSigning:
       allOf:
         - $ref: '#/components/schemas/Signing'
+        - $ref: '#/components/schemas/ProposerPreferencesRequest'
         - type: object
           properties:
             type:
@@ -396,13 +481,36 @@ components:
               description: Signing Request type
               enum:
                 - 'PROPOSER_PREFERENCES'
-            proposer_preferences:
-              "$ref": "#/components/schemas/ProposerPreferences"
           required:
             - type
-            - proposer_preferences
+    ProposerPreferencesRequest:
+      type: object
+      properties:
+        proposer_preferences:
+          oneOf:
+            - $ref: '#/components/schemas/ProposerPreferencesRequestGloas'
+          discriminator:
+            propertyName: version
+            mapping:
+              GLOAS: '#/components/schemas/ProposerPreferencesRequestGloas'
+      required:
+        - proposer_preferences
+    ProposerPreferencesRequestGloas:
+      type: object
+      properties:
+        version:
+          type: string
+          enum:
+            - GLOAS
+          description: 'version to identify ProposerPreferences request type.'
+        data:
+          $ref: "#/components/schemas/ProposerPreferencesGloas"
+      required:
+        - version
+        - data
     BuilderRequestAuthSigning:
       allOf:
+        - $ref: '#/components/schemas/BuilderRequestAuthRequest'
         - type: object
           properties:
             type:
@@ -413,11 +521,33 @@ components:
             signingRoot:
               type: "string"
               description: 'signing root for optional verification if field present'
-            builder_request_auth:
-              "$ref": "#/components/schemas/BuilderRequestAuth"
           required:
             - type
-            - builder_request_auth
+    BuilderRequestAuthRequest:
+      type: object
+      properties:
+        builder_request_auth:
+          oneOf:
+            - $ref: '#/components/schemas/BuilderRequestAuthRequestGloas'
+          discriminator:
+            propertyName: version
+            mapping:
+              GLOAS: '#/components/schemas/BuilderRequestAuthRequestGloas'
+      required:
+        - builder_request_auth
+    BuilderRequestAuthRequestGloas:
+      type: object
+      properties:
+        version:
+          type: string
+          enum:
+            - GLOAS
+          description: 'version to identify BuilderRequestAuth request type.'
+        data:
+          $ref: "#/components/schemas/BuilderRequestAuthGloas"
+      required:
+        - version
+        - data
     RandaoReveal:
       type: "object"
       properties:
@@ -709,7 +839,7 @@ components:
           format: uint64
         pubkey:
           type: string
-    ExecutionPayloadBid:
+    ExecutionPayloadBidGloas:
       type: object
       description: >-
         SSZ container signed by a builder using DOMAIN_BEACON_BUILDER (0x0B000000)
@@ -749,24 +879,20 @@ components:
           type: array
           items:
             type: string
-            description: Bytes48 hexadecimal KZG commitment
+            description: Bytes48 hexadecimal
         execution_requests_root:
           type: string
-          description: Bytes32 hash-tree-root of the execution requests
-    ExecutionPayloadEnvelope:
+          description: Bytes32 hexadecimal
+    ExecutionPayloadEnvelopeGloas:
       type: object
       description: >-
         SSZ container signed by a builder using DOMAIN_BEACON_BUILDER (0x0B000000)
         in Glamsterdam (ePBS) when revealing the actual execution payload.
       properties:
         payload:
-          description: 'Execution payload (Glamsterdam shape, see ExecutionPayloadGloas)'
           $ref: '#/components/schemas/ExecutionPayloadGloas'
         execution_requests:
-          description: >-
-            Execution requests (deposits, withdrawals, consolidations; plus
-            builder_deposits/builder_exits from Gloas, EIP-8282)
-          type: object
+          $ref: '#/components/schemas/ExecutionRequestsGloas'
         builder_index:
           type: string
           format: uint64
@@ -815,7 +941,7 @@ components:
           format: uint64
         extra_data:
           type: string
-          description: variable-length bytes
+          description: SSZ hexadecimal
         base_fee_per_gas:
           type: string
           description: UInt256 decimal
@@ -826,7 +952,7 @@ components:
           type: array
           items:
             type: string
-            description: variable-length bytes (RLP-encoded transaction)
+            description: SSZ hexadecimal
         withdrawals:
           type: array
           description: List of validator withdrawals (Capella+).
@@ -853,11 +979,94 @@ components:
           format: uint64
         block_access_list:
           type: string
-          description: variable-length bytes (block access list)
+          description: SSZ hexadecimal
         slot_number:
           type: string
           format: uint64
-    PayloadAttestationData:
+    ExecutionRequestsGloas:
+      type: object
+      description: >-
+        Glamsterdam execution requests. Extends the Electra execution requests
+        (deposits, withdrawals, consolidations) with builder_deposits and
+        builder_exits (EIP-8282).
+      properties:
+        deposits:
+          type: array
+          items:
+            type: object
+            properties:
+              pubkey:
+                type: string
+                description: Bytes48 hexadecimal
+              withdrawal_credentials:
+                type: string
+                description: Bytes32 hexadecimal
+              amount:
+                type: string
+                format: uint64
+              signature:
+                type: string
+                description: Bytes96 hexadecimal
+              index:
+                type: string
+                format: uint64
+        withdrawals:
+          type: array
+          items:
+            type: object
+            properties:
+              source_address:
+                type: string
+                description: Bytes20 hexadecimal
+              validator_pubkey:
+                type: string
+                description: Bytes48 hexadecimal
+              amount:
+                type: string
+                format: uint64
+        consolidations:
+          type: array
+          items:
+            type: object
+            properties:
+              source_address:
+                type: string
+                description: Bytes20 hexadecimal
+              source_pubkey:
+                type: string
+                description: Bytes48 hexadecimal
+              target_pubkey:
+                type: string
+                description: Bytes48 hexadecimal
+        builder_deposits:
+          type: array
+          items:
+            type: object
+            properties:
+              pubkey:
+                type: string
+                description: Bytes48 hexadecimal
+              withdrawal_credentials:
+                type: string
+                description: Bytes32 hexadecimal
+              amount:
+                type: string
+                format: uint64
+              signature:
+                type: string
+                description: Bytes96 hexadecimal
+        builder_exits:
+          type: array
+          items:
+            type: object
+            properties:
+              source_address:
+                type: string
+                description: Bytes20 hexadecimal
+              pubkey:
+                type: string
+                description: Bytes48 hexadecimal
+    PayloadAttestationDataGloas:
       type: object
       description: >-
         The data component of a PayloadAttestationMessage, signed by a PTC
@@ -877,7 +1086,7 @@ components:
         blob_data_available:
           type: boolean
           description: Whether blob data is available for this slot
-    ProposerPreferences:
+    ProposerPreferencesGloas:
       type: object
       description: >-
         Container signed by a proposer using DOMAIN_PROPOSER_PREFERENCES
@@ -899,22 +1108,25 @@ components:
         target_gas_limit:
           type: string
           format: uint64
-    BuilderRequestAuth:
+    BuilderRequestAuthGloas:
       type: object
       description: >-
         Proposer-signed, out-of-protocol builder-API authentication message
         (builder-specs, Gloas), used to authenticate per-request builder-API
-        calls (e.g. getExecutionPayloadBid). Signed with DOMAIN_BUILDER_REQUEST_AUTH
-        (0x0B000001) computed from the genesis fork version and a zero
-        genesis_validators_root (no fork_info required), not the proposer's
-        current fork.
+        calls (e.g. getExecutionPayloadBid, submitBuilderPreferences). Signed
+        with DOMAIN_BUILDER_REQUEST_AUTH (0x0B000001) computed from the genesis
+        fork version and a zero genesis_validators_root (no fork_info required),
+        not the proposer's current fork.
       properties:
         data:
           type: string
-          description: variable-length bytes (opaque per-builder authorization data)
+          description: >-
+            SSZ hexadecimal (max 4096 bytes, non-empty). Opaque authentication
+            data agreed with the builder out of band.
         slot:
           type: string
           format: uint64
+          description: The proposal slot this request is authorized for.
     BeaconBlockSigning:
       allOf:
         - $ref: '#/components/schemas/Signing'
@@ -941,6 +1153,7 @@ components:
             - $ref: '#/components/schemas/BlockRequestDeneb'
             - $ref: '#/components/schemas/BlockRequestElectra'
             - $ref: '#/components/schemas/BlockRequestFulu'
+            - $ref: '#/components/schemas/BlockRequestGloas'
           discriminator:
             propertyName: version
             mapping:
@@ -951,6 +1164,7 @@ components:
               DENEB: '#/components/schemas/BlockRequestDeneb'
               ELECTRA: '#/components/schemas/BlockRequestElectra'
               FULU: '#/components/schemas/BlockRequestFulu'
+              GLOAS: '#/components/schemas/BlockRequestGloas'
       required:
         - beacon_block
     BlockRequestPhase0:
@@ -1038,6 +1252,19 @@ components:
           type: string
           enum:
             - FULU
+          description: 'version to identify block request type.'
+        block_header:
+          $ref: "#/components/schemas/BeaconBlockHeader"
+      required:
+        - version
+        - block_header
+    BlockRequestGloas:
+      type: object
+      properties:
+        version:
+          type: string
+          enum:
+            - GLOAS
           description: 'version to identify block request type.'
         block_header:
           $ref: "#/components/schemas/BeaconBlockHeader"

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -303,7 +303,7 @@ components:
               type: "string"
               description: Signing Request type
               enum:
-               - 'SYNC_COMMITTEE_SELECTION_PROOF'
+                - 'SYNC_COMMITTEE_SELECTION_PROOF'
             sync_aggregator_selection_data:
               $ref: "#/components/schemas/SyncAggregatorSelectionData"
           required:
@@ -318,7 +318,7 @@ components:
               type: "string"
               description: Signing Request type
               enum:
-               - 'SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF'
+                - 'SYNC_COMMITTEE_CONTRIBUTION_AND_PROOF'
             contribution_and_proof:
               $ref: "#/components/schemas/ContributionAndProof"
           required:

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -902,9 +902,12 @@ components:
     BuilderRequestAuth:
       type: object
       description: >-
-        Proposer-signed builder-API auth message (builder-specs, Gloas) using
-        DOMAIN_BUILDER_REQUEST_AUTH (0x0B000001), analogous to the deprecated
-        ValidatorRegistrationV1 flow (genesis fork version, no fork_info needed).
+        Proposer-signed, out-of-protocol builder-API authentication message
+        (builder-specs, Gloas), used to authenticate per-request builder-API
+        calls (e.g. getExecutionPayloadBid). Signed with DOMAIN_BUILDER_REQUEST_AUTH
+        (0x0B000001) computed from the genesis fork version and a zero
+        genesis_validators_root (no fork_info required), not the proposer's
+        current fork.
       properties:
         data:
           type: string

--- a/signing/schemas.yaml
+++ b/signing/schemas.yaml
@@ -401,6 +401,23 @@ components:
           required:
             - type
             - proposer_preferences
+    BuilderRequestAuthSigning:
+      allOf:
+        - type: object
+          properties:
+            type:
+              type: "string"
+              description: Signing Request type
+              enum:
+                - 'BUILDER_REQUEST_AUTH'
+            signingRoot:
+              type: "string"
+              description: 'signing root for optional verification if field present'
+            builder_request_auth:
+              "$ref": "#/components/schemas/BuilderRequestAuth"
+          required:
+            - type
+            - builder_request_auth
     RandaoReveal:
       type: "object"
       properties:
@@ -746,12 +763,17 @@ components:
           description: 'Execution payload (Glamsterdam shape, see ExecutionPayloadGloas)'
           $ref: '#/components/schemas/ExecutionPayloadGloas'
         execution_requests:
-          description: 'Execution requests (deposits, withdrawals, consolidations)'
+          description: >-
+            Execution requests (deposits, withdrawals, consolidations; plus
+            builder_deposits/builder_exits from Gloas, EIP-8282)
           type: object
         builder_index:
           type: string
           format: uint64
         beacon_block_root:
+          type: string
+          description: Bytes32 hexadecimal
+        parent_beacon_block_root:
           type: string
           description: Bytes32 hexadecimal
     ExecutionPayloadGloas:
@@ -859,9 +881,12 @@ components:
       type: object
       description: >-
         Container signed by a proposer using DOMAIN_PROPOSER_PREFERENCES
-        (0x0D000000) to advertise their preferences (fee_recipient, gas_limit)
-        for an upcoming proposal slot.
+        (0x0D000000) to advertise their preferences (fee_recipient,
+        target_gas_limit) for an upcoming proposal slot.
       properties:
+        dependent_root:
+          type: string
+          description: Bytes32 hexadecimal
         proposal_slot:
           type: string
           format: uint64
@@ -871,7 +896,20 @@ components:
         fee_recipient:
           type: string
           description: Bytes20 hexadecimal
-        gas_limit:
+        target_gas_limit:
+          type: string
+          format: uint64
+    BuilderRequestAuth:
+      type: object
+      description: >-
+        Proposer-signed builder-API auth message (builder-specs, Gloas) using
+        DOMAIN_BUILDER_REQUEST_AUTH (0x0B000001), analogous to the deprecated
+        ValidatorRegistrationV1 flow (genesis fork version, no fork_info needed).
+      properties:
+        data:
+          type: string
+          description: variable-length bytes (opaque per-builder authorization data)
+        slot:
           type: string
           format: uint64
     BeaconBlockSigning:


### PR DESCRIPTION
## Summary

Adds five new signing types for the upcoming **Gloas** fork (Glamsterdam). These are client-agnostic spec additions intended for any consensus client (Teku, Lighthouse, Lodestar, Nimbus, Prysm) interacting with a remote signer such as Web3Signer.

| Type | Domain | Signer role |
|---|---|---|
| `EXECUTION_PAYLOAD_BID` | `DOMAIN_BEACON_BUILDER` (0x0B000000) | Builder |
| `EXECUTION_PAYLOAD_ENVELOPE` | `DOMAIN_BEACON_BUILDER` (0x0B000000) | Builder |
| `PAYLOAD_ATTESTATION_MESSAGE` | `DOMAIN_PTC_ATTESTER` (0x0C000000) | PTC attester |
| `PROPOSER_PREFERENCES` | `DOMAIN_PROPOSER_PREFERENCES` (0x0D000000) | Proposer |
| `BUILDER_REQUEST_AUTH` | `DOMAIN_BUILDER_REQUEST_AUTH` (0x0B000001) | Proposer |

### Request shape

All five payloads are fork-versioned, following the existing `BLOCK_V2` / `AGGREGATE_AND_PROOF_V2` pattern:

```json
{
  "type": "EXECUTION_PAYLOAD_BID",
  "fork_info": { ... },
  "execution_payload_bid": {
    "version": "GLOAS",
    "data": { ... }
  }
}
```

`BUILDER_REQUEST_AUTH` is the exception on `fork_info`: like `VALIDATOR_REGISTRATION`, it is signed with `compute_domain(DOMAIN_BUILDER_REQUEST_AUTH)` (genesis fork version, zero `genesis_validators_root`), so `fork_info` is not required. It is still `version`-wrapped.

### Schema additions

- `ExecutionPayloadBidGloas` (12 fields, incl. `execution_requests_root`)
- `ExecutionPayloadEnvelopeGloas` (`payload`, `execution_requests`, `builder_index`, `beacon_block_root`, `parent_beacon_block_root`)
- `ExecutionPayloadGloas` (Deneb shape + `block_access_list`, `slot_number`)
- `ExecutionRequestsGloas` (`deposits`, `withdrawals`, `consolidations`, `builder_deposits`, `builder_exits`)
- `PayloadAttestationDataGloas` (4 fields)
- `ProposerPreferencesGloas` (`dependent_root`, `proposal_slot`, `validator_index`, `fee_recipient`, `target_gas_limit`)
- `BuilderRequestAuthGloas` (`data`, `slot`)
- `BlockRequestGloas`, `AggregateAndProofRequestGloas` — `GLOAS` added to `BLOCK_V2` and `AGGREGATE_AND_PROOF_V2` (JSON shapes unchanged from Fulu; only SSZ encoding differs)

`/sign` endpoint's `oneOf` + discriminator mapping is extended with the five new types; a request example is provided for each, plus `BLOCK_V2 (GLOAS)` and `AGGREGATE_AND_PROOF_V2 (GLOAS)`.

Tracks #23.

## :warning: Subject to change

Field shapes mirror the current `consensus-specs` `gloas/` and `builder-specs` `gloas/` containers. Other client teams should review and push back on:
- Field names / casing.
- Whether `PROPOSER_PREFERENCES` belongs in the spec at this layer or is something proposers handle locally.
- Whether `BUILDER_REQUEST_AUTH` is scoped/named correctly against the current `builder-specs` (Gloas) `BuilderRequestAuth`/`SignedBuilderRequestAuth` containers.

Spec is published as **draft** and will be revised once cross-client consensus is reached.

## Review history

- @james-prysm / @JasonVranek: added `BUILDER_REQUEST_AUTH` per builder-specs#165 / beacon-APIs#630; synced `ProposerPreferences` / `ExecutionPayloadEnvelope` with spec.
- @nflaig: all new payloads now `version`-wrapped for forward compatibility (`8742bd7`).
- @james-prysm: `execution_requests` is now fully typed (`ExecutionRequestsGloas`); `BLOCK_V2` and `AGGREGATE_AND_PROOF_V2` accept `GLOAS` (`8742bd7`).

Note: the `version`/`data` wrapper was a breaking change relative to the earlier draft validated in Consensys-Incorporated/web3signer#1192 — that implementation has been updated to match (web3signer@27431fbc, web3signer@5670340b).

## Test plan

- [x] Spec lints (spectral, 0 errors) and bundles (swagger-cli)
- [ ] Cross-client review — Lodestar ✅ (@nflaig), Prysm ✅ (@james-prysm); Teku, Lighthouse, Nimbus outstanding
- [ ] Field name alignment with EIP/CL spec PRs for ePBS
- [x] Re-validate against updated Web3Signer implementation (Consensys-Incorporated/web3signer#1192) — wrapper shape and doc fixes synced (`27431fbc`, `5670340b`)



